### PR TITLE
DbalExtension - schemaAssetsFilter: Allow services 

### DIFF
--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -41,7 +41,7 @@ final class DbalExtension extends CompilerExtension
 			'configuration' => Expect::structure([
 				'sqlLogger' => Expect::anyOf(Expect::string(), Expect::array(), Expect::type(Statement::class)),
 				'resultCache' => Expect::anyOf(Expect::string(), Expect::array(), Expect::type(Statement::class)),
-				'schemaAssetsFilter' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
+				'schemaAssetsFilter' => Expect::anyOf(Expect::string(), Expect::array(), Expect::type(Statement::class)),
 				'filterSchemaAssetsExpression' => Expect::string()->nullable(),
 				'autoCommit' => Expect::bool(true),
 			]),


### PR DESCRIPTION
Allow services to be used as schemaAssetFilter:

``` neon
nettrine.dbal:
	configuration:
		schemaAssetsFilter: [@MySchemaAssetFilterService, filter]
```