### PR TITLE
Extension: support custom SchemaManagerFactory

### DIFF
--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -51,6 +51,7 @@ class DbalExtension extends CompilerExtension
 				'resultCache' => Expect::anyOf($expectService),
 				'schemaAssetsFilter' => Expect::anyOf($expectService),
 				'filterSchemaAssetsExpression' => Expect::string()->nullable(),
+				'schemaManagerFactory' => Expect::anyOf($expectService),
 				'autoCommit' => Expect::bool(true),
 			]),
 			'connection' => Expect::structure([
@@ -109,6 +110,11 @@ class DbalExtension extends CompilerExtension
 		// FilterSchemaAssetsExpression
 		if ($configurationConfig->filterSchemaAssetsExpression !== null) {
 			$configuration->addSetup('setFilterSchemaAssetsExpression', [$configurationConfig->filterSchemaAssetsExpression]);
+		}
+
+		// SchemaManagerFactory
+		if ($configurationConfig->schemaManagerFactory !== null) {
+			$configuration->addSetup('setSchemaManagerFactory', [$configurationConfig->schemaManagerFactory]);
 		}
 
 		// AutoCommit


### PR DESCRIPTION
We have some GIN indexes using trgm extension for Postgres in our projects.

The problem is that Doctrine does not support them and due to this fact the schema validation insists on dropping them.

We need to be able to ignore such indexes in the doctrine dbal schema parser.

So I created my own SchemaManager that keeps a list of indexes to ignore. Then registered my own PlatformService into Connection with an overridden createSchemaManager method.

That should be enough. Unfortunately, this assumes that the project uses DefaultSchemaManagerFactory, which will be the default from DBAL 4. Until then, unless the configuration says otherwise, the LegacySchemaManagerFactory is used.

The purpose of this pull request is to allow you to pass the DefaultSchemaManagerFactory (or any other service of this type) to the Doctrine configuration.

More info about the indexes issue and its solution could be found [here](https://medium.com/yousign-engineering-product/ignore-custom-indexes-on-doctrine-dbal-b5131dd22071).