### PR TITLE
DBAL 4 compatibility

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -143,10 +143,7 @@ nettrine.dbal:
   connection:
     types:
       uuid: Ramsey\Uuid\Doctrine\UuidType
-
-      uuid_binary_ordered_time:
-        class: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
-        commented: false
+      uuid_binary_ordered_time: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
 
     typesMapping:
       uuid_binary_ordered_time: binary

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -139,7 +139,7 @@ Take a look at real **Nettrine DBAL** configuration example at [contributte/weba
 Here is an example of how to register custom type for [UUID](https://github.com/ramsey/uuid-doctrine).
 
 ```neon
-dbal:
+nettrine.dbal:
   connection:
     types:
       uuid: Ramsey\Uuid\Doctrine\UuidType
@@ -172,7 +172,7 @@ Alternatively, specify your application root path under the `debug.sourcePaths` 
 Middlewares are the way how to extend doctrine library or hook to special events.
 
 ```neon
-dbal:
+nettrine.dbal:
   connection:
     middlewares:
       - MyMiddleware
@@ -220,7 +220,7 @@ final class MyDriver extends AbstractDriverMiddleware
 To log all queries you should define your own middleware or you can use `Doctrine\DBAL\Logging\Middleware`.
 
 ```neon
-dbal:
+nettrine.dbal:
   configuration:
     middlewares:
       logger: Doctrine\DBAL\Logging\Middleware(MyLogger())
@@ -230,7 +230,7 @@ You can try our prepared loggers.
 
 
 ```neon
-dbal:
+nettrine.dbal:
   configuration:
     middlewares:
       # Write logs to file

--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,9 +6,9 @@
 ## Content
 
 - [Setup](#setup)
-- [Relying](#relying)
+  - [Console](#console)
 - [Configuration](#configuration)
-- [Usage](#usage)
+  - [Caching](#caching)
   - [Types](#types)
   - [Debug](#debug)
   - [Events](#events)
@@ -34,33 +34,9 @@ extensions:
 ```
 
 
-## Relying
+### Console
 
-Take advantage of enpowering this package with 2 extra packages:
-
-- `doctrine/cache`
-- `symfony/console`
-
-
-### `doctrine/cache`
-
-This package relies on `doctrine/cache`, use prepared [nettrine/cache](https://github.com/contributte/doctrine-cache) integration.
-
-```bash
-composer require nettrine/cache
-```
-
-```neon
-extensions:
-  nettrine.cache: Nettrine\Cache\DI\CacheExtension
-```
-
-[Doctrine DBAL](https://www.doctrine-project.org/projects/dbal.html) needs [Doctrine Cache](https://www.doctrine-project.org/projects/cache.html) to be configured. If you register `nettrine/cache` extension it will detect it automatically.
-
-
-### `symfony/console`
-
-This package relies on `symfony/console`, use prepared [contributte/console](https://github.com/contributte/console) integration.
+Take advantage of empowering this package with `symfony/console`and prepared [contributte/console](https://github.com/contributte/console) integration.
 
 ```bash
 composer require contributte/console
@@ -133,6 +109,50 @@ nettrine.dbal:
 
 Take a look at real **Nettrine DBAL** configuration example at [contributte/webapp-project](https://github.com/contributte/webapp-skeleton/blob/d23e6cbac9b91d6d069583f1661dd1171ccfe077/app/config/ext/nettrine.neon).
 
+
+### Caching
+
+By default, [result cache](https://www.doctrine-project.org/projects/doctrine-dbal/en/4.0/reference/caching.html) is configured to the autowired [cache storage](https://doc.nette.org/cs/caching#toc-sluzby-di). You can configure it to other [storage](https://doc.nette.org/cs/caching#toc-uloziste), [cache](https://api.nette.org/caching/master/Nette/Caching/Cache.html) or [cache pool](https://www.php-fig.org/psr/psr-6/#cacheitempoolinterface).
+
+Use different storage:
+
+```neon
+nettrine.dbal:
+  configuration:
+    resultCache: Nette\Caching\Storages\MemoryStorage
+```
+
+Use cache:
+
+```neon
+nettrine.dbal:
+  configuration:
+    resultCache: Nette\Caching\Cache(namespace: 'dbal-result-cache')
+```
+
+Use cache pool:
+
+```neon
+nettrine.dbal:
+  configuration:
+    resultCache: Contributte\Psr6\CachePool(Nette\Caching\Cache(namespace: 'dbal-result-cache'))
+```
+
+Use registered service (service must be of type `Nette\Caching\Storage`, `Nette\Caching\Cache` or `Psr\Cache\CacheItemPoolInterface`):
+
+```neon
+nettrine.dbal:
+  configuration:
+    resultCache: @service
+```
+
+If you want to turn cache off, you can use `DevNullStorage` to do so:
+
+```neon
+nettrine.dbal:
+  configuration:
+    resultCache: Nette\Caching\Storages\DevNullStorage
+```
 
 ### Types
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "require": {
     "php": ">=8.1",
     "nette/di": "^3.2.2",
-    "doctrine/dbal": "^3.6.7",
+    "doctrine/dbal": "^3.6.7 || ^4.0",
     "nettrine/cache": "^0.4.0 || ^0.5.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
   ],
   "require": {
     "php": ">=8.1",
-    "nette/di": "^3.2.2",
+    "contributte/psr6-caching": "^0.2 || ^0.3",
     "doctrine/dbal": "^3.6.7 || ^4.0",
-    "nettrine/cache": "^0.4.0 || ^0.5.0"
+    "nette/di": "^3.2.2"
   },
   "require-dev": {
     "ext-pdo": "*",

--- a/src/ConnectionFactory.php
+++ b/src/ConnectionFactory.php
@@ -11,19 +11,16 @@ use Doctrine\DBAL\Types\Type;
 class ConnectionFactory
 {
 
-	/** @var array<string, array{class: class-string<Type>, commented: bool}> */
+	/** @var array<string, class-string<Type>> */
 	private array $typesConfig = [];
 
 	/** @var array<string, string> */
 	private array $typesMapping = [];
 
-	/** @var array<string> */
-	private array $commentedTypes = [];
-
 	private bool $initialized = false;
 
 	/**
-	 * @param array<string, array{class: class-string<Type>, commented: bool}> $typesConfig
+	 * @param array<string, class-string<Type>> $typesConfig
 	 * @param array<string, string> $typesMapping
 	 */
 	public function __construct(array $typesConfig = [], array $typesMapping = [])
@@ -49,24 +46,16 @@ class ConnectionFactory
 			$platform->registerDoctrineTypeMapping($dbType, $doctrineType);
 		}
 
-		foreach ($this->commentedTypes as $type) {
-			$platform->markDoctrineTypeCommented(Type::getType($type));
-		}
-
 		return $connection;
 	}
 
 	private function initializeTypes(): void
 	{
-		foreach ($this->typesConfig as $type => $typeConfig) {
+		foreach ($this->typesConfig as $type => $class) {
 			if (Type::hasType($type)) {
-				Type::overrideType($type, $typeConfig['class']);
+				Type::overrideType($type, $class);
 			} else {
-				Type::addType($type, $typeConfig['class']);
-			}
-
-			if ($typeConfig['commented']) {
-				$this->commentedTypes[] = $type;
+				Type::addType($type, $class);
 			}
 		}
 

--- a/src/DI/DbalExtension.php
+++ b/src/DI/DbalExtension.php
@@ -56,20 +56,7 @@ class DbalExtension extends CompilerExtension
 			]),
 			'connection' => Expect::structure([
 				'driver' => Expect::mixed()->required(),
-				'types' => Expect::arrayOf(
-					Expect::structure([
-						'class' => Expect::string()->required(),
-						'commented' => Expect::bool(false),
-					])
-						->before(function ($type) {
-							if (is_string($type)) {
-								return ['class' => $type];
-							}
-
-							return $type;
-						})
-						->castTo('array')
-				),
+				'types' => Expect::arrayOf('string', 'string'),
 				'typesMapping' => Expect::array(),
 			])->otherItems()->castTo('array'),
 		]);

--- a/tests/Cases/ConnectionFactory.types.phpt
+++ b/tests/Cases/ConnectionFactory.types.phpt
@@ -11,10 +11,7 @@ require_once __DIR__ . '/../bootstrap.php';
 
 Toolkit::test(function (): void {
 	$types = [
-		'foo' => [
-			'class' => StringType::class,
-			'commented' => false,
-		],
+		'foo' => StringType::class,
 	];
 	$mapping = [
 		'db_foo' => 'foo',

--- a/tests/Cases/DI/DbalExtension.cache.phpt
+++ b/tests/Cases/DI/DbalExtension.cache.phpt
@@ -2,41 +2,92 @@
 
 namespace Tests\Cases\DI;
 
+use Contributte\Psr6\CachePool;
 use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
+use Nette\Bridges\CacheDI\CacheExtension;
+use Nette\Caching\Cache;
+use Nette\Caching\Storage;
+use Nette\Caching\Storages\MemoryStorage;
 use Nette\DI\Compiler;
-use Nette\DI\ServiceCreationException;
+use Nette\DI\Definitions\Statement;
 use Nettrine\DBAL\DI\DbalExtension;
+use Psr\Cache\CacheItemPoolInterface;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
 use Tracy\Bridges\Nette\TracyExtension;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
-// Exception (no cache extension)
+// no cache configuration
 Toolkit::test(function (): void {
-	Assert::exception(
-		function (): void {
-			ContainerBuilder::of()
-				->withCompiler(static function (Compiler $compiler): void {
-					$compiler->addExtension('nettrine.dbal', new DbalExtension());
-					$compiler->addExtension('nette.tracy', new TracyExtension());
-					$compiler->addConfig([
-						'parameters' => [
-							'tempDir' => Tests::TEMP_PATH,
-							'appDir' => Tests::APP_PATH,
-						],
-					]);
-					$compiler->addConfig(Neonkit::load(<<<'NEON'
-						nettrine.dbal:
-							connection:
-								driver: pdo_sqlite
-					NEON
-					));
-				})->build();
-		},
-		ServiceCreationException::class,
-		"~^Service 'nettrine\\.dbal\\.configuration' \\(type of Doctrine\\\\DBAL\\\\Configuration\\): Service of type '?Doctrine\\\\Common\\\\Cache\\\\Cache'? not found\.~"
-	);
+	$container = ContainerBuilder::of()
+		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
+			$compiler->addExtension('nettrine.dbal', new DbalExtension());
+			$compiler->addExtension('nette.tracy', new TracyExtension());
+			$compiler->addConfig([
+				'parameters' => [
+					'tempDir' => Tests::TEMP_PATH,
+					'appDir' => Tests::APP_PATH,
+				],
+			]);
+			$compiler->addConfig(Neonkit::load(<<<'NEON'
+				nettrine.dbal:
+					connection:
+						driver: pdo_sqlite
+			NEON
+			));
+		})->build();
+
+	Assert::type(CacheItemPoolInterface::class, $container->getByName('nettrine.dbal.configuration')->getResultCache());
 });
+
+// cache configuration
+$cacheDefinitions = [
+	'Contributte\Psr6\CachePool(Nette\Caching\Cache(@Nette\Caching\Storage, "result-cache"))',
+	'Contributte\Psr6\CachePool(Nette\Caching\Cache(namespace: "result-cache"))',
+	'Nette\Caching\Cache(@Nette\Caching\Storage, "result-cache")',
+	'Nette\Caching\Cache(namespace: "result-cache")',
+	'Nette\Caching\Storages\MemoryStorage',
+	'@svcCachePool',
+	'@svcCache',
+	'@svcStorage',
+	'@' . CachePool::class,
+	'@' . Cache::class,
+	'@' . Storage::class,
+];
+foreach ($cacheDefinitions as $cacheDefinition) {
+	Toolkit::test(function () use ($cacheDefinition): void {
+		$container = ContainerBuilder::of()
+			->withCompiler(static function (Compiler $compiler) use ($cacheDefinition): void {
+				$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
+				$compiler->addExtension('nettrine.dbal', new DbalExtension());
+				$compiler->addExtension('nette.tracy', new TracyExtension());
+				$compiler->addConfig([
+					'parameters' => [
+						'tempDir' => Tests::TEMP_PATH,
+						'appDir' => Tests::APP_PATH,
+					],
+				]);
+				$compiler->getContainerBuilder()->addDefinition('svcCachePool')
+					->setFactory(new Statement(CachePool::class, [new Statement(Cache::class, [1 => Tests::TEMP_PATH])]));
+				$compiler->getContainerBuilder()->addDefinition('svcCache')
+					->setFactory(new Statement(Cache::class, [1 => Tests::TEMP_PATH]));
+				$compiler->getContainerBuilder()->addDefinition('svcStorage')
+					->setFactory(MemoryStorage::class)
+					->setAutowired(false);
+				$compiler->addConfig(Neonkit::load(<<<NEON
+				nettrine.dbal:
+					connection:
+						driver: pdo_sqlite
+					configuration:
+						resultCache: $cacheDefinition
+			NEON
+				));
+			})->build();
+
+		Assert::type(CacheItemPoolInterface::class, $container->getByName('nettrine.dbal.configuration')->getResultCache());
+	});
+}

--- a/tests/Cases/DI/DbalExtension.debugMode.phpt
+++ b/tests/Cases/DI/DbalExtension.debugMode.phpt
@@ -6,8 +6,8 @@ use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Liberator;
 use Contributte\Tester\Utils\Neonkit;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
@@ -20,8 +20,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [

--- a/tests/Cases/DI/DbalExtension.events.phpt
+++ b/tests/Cases/DI/DbalExtension.events.phpt
@@ -60,7 +60,7 @@ Toolkit::test(function (): void {
 					connection:
 						driver: pdo_sqlite
 						types:
-							foo: { class: Doctrine\DBAL\Types\StringType }
+							foo: Doctrine\DBAL\Types\StringType
 							bar: Doctrine\DBAL\Types\IntegerType
 
 				services:

--- a/tests/Cases/DI/DbalExtension.events.phpt
+++ b/tests/Cases/DI/DbalExtension.events.phpt
@@ -7,8 +7,8 @@ use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Events;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
@@ -20,8 +20,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addConfig([
 				'parameters' => [
 					'tempDir' => Tests::TEMP_PATH,
@@ -46,8 +46,8 @@ Toolkit::test(function (): void {
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [

--- a/tests/Cases/DI/DbalExtension.middlewares.phpt
+++ b/tests/Cases/DI/DbalExtension.middlewares.phpt
@@ -7,19 +7,20 @@ use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\DBAL\Connection;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
 use Nette\DI\InvalidConfigurationException;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Fixtures\Driver\TestDriver;
+use Tests\Toolkit\Tests;
 
 require_once __DIR__ . '/../../bootstrap.php';
 
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(function (Compiler $compiler): void {
-			$compiler->addExtension('cache', new CacheExtension());
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('dbal', new DbalExtension());
 			$compiler->addConfig(Neonkit::load('
 				dbal:

--- a/tests/Cases/DI/DbalExtension.platform.phpt
+++ b/tests/Cases/DI/DbalExtension.platform.phpt
@@ -7,8 +7,8 @@ use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySQL80Platform;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
@@ -20,8 +20,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [

--- a/tests/Cases/DI/DbalExtension.platform.phpt
+++ b/tests/Cases/DI/DbalExtension.platform.phpt
@@ -6,7 +6,7 @@ use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
+use Doctrine\DBAL\Platforms\MySQL80Platform;
 use Nette\DI\Compiler;
 use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
@@ -32,8 +32,8 @@ Toolkit::test(function (): void {
 			$compiler->addConfig(Neonkit::load(<<<'NEON'
 				nettrine.dbal:
 					connection:
-						driver: pdo_pgsql
-						serverVersion: 10.0
+						driver: pdo_mysql
+						serverVersion: '8.0.0'
 			NEON
 			));
 		})->build();
@@ -41,6 +41,6 @@ Toolkit::test(function (): void {
 	/** @var Connection $connection */
 	$connection = $container->getByType(Connection::class);
 
-	Assert::type(PostgreSQL100Platform::class, $connection->getDatabasePlatform());
+	Assert::type(MySQL80Platform::class, $connection->getDatabasePlatform());
 	Assert::falsey($connection->isConnected());
 });

--- a/tests/Cases/DI/DbalExtension.schemaFilter.phpt
+++ b/tests/Cases/DI/DbalExtension.schemaFilter.phpt
@@ -6,8 +6,8 @@ use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\DBAL\Configuration;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
@@ -19,8 +19,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [
@@ -49,8 +49,8 @@ Toolkit::test(function (): void {
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [

--- a/tests/Cases/DI/DbalExtension.types.phpt
+++ b/tests/Cases/DI/DbalExtension.types.phpt
@@ -9,8 +9,8 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\IntegerType;
 use Doctrine\DBAL\Types\StringType;
 use Doctrine\DBAL\Types\Type;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
 use Tests\Toolkit\Tests;
@@ -22,8 +22,8 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(static function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
 			$compiler->addExtension('nettrine.dbal', new DbalExtension());
-			$compiler->addExtension('nettrine.cache', new CacheExtension());
 			$compiler->addExtension('nette.tracy', new TracyExtension());
 			$compiler->addConfig([
 				'parameters' => [

--- a/tests/Cases/DI/DbalExtension.types.phpt
+++ b/tests/Cases/DI/DbalExtension.types.phpt
@@ -36,7 +36,7 @@ Toolkit::test(function (): void {
 					connection:
 						driver: pdo_sqlite
 						types:
-							foo: { class: Doctrine\DBAL\Types\StringType }
+							foo: Doctrine\DBAL\Types\StringType
 							bar: Doctrine\DBAL\Types\IntegerType
 			NEON
 			));

--- a/tests/Cases/E2E/QueryTest.phpt
+++ b/tests/Cases/E2E/QueryTest.phpt
@@ -2,15 +2,17 @@
 
 namespace Tests\Cases\E2E;
 
+use Contributte\Psr6\DI\Psr6CachingExtension;
 use Contributte\Tester\Environment;
 use Contributte\Tester\Toolkit;
 use Contributte\Tester\Utils\ContainerBuilder;
 use Contributte\Tester\Utils\Neonkit;
 use Doctrine\DBAL\Connection;
+use Nette\Bridges\CacheDI\CacheExtension;
 use Nette\DI\Compiler;
-use Nettrine\Cache\DI\CacheExtension;
 use Nettrine\DBAL\DI\DbalExtension;
 use Tester\Assert;
+use Tests\Toolkit\Tests;
 use Tracy\Bridges\Nette\TracyExtension;
 
 require_once __DIR__ . '/../../bootstrap.php';
@@ -18,8 +20,9 @@ require_once __DIR__ . '/../../bootstrap.php';
 Toolkit::test(function (): void {
 	$container = ContainerBuilder::of()
 		->withCompiler(function (Compiler $compiler): void {
+			$compiler->addExtension('cache', new CacheExtension(Tests::TEMP_PATH));
+			$compiler->addExtension('psr6', new Psr6CachingExtension());
 			$compiler->addExtension('tracy', new TracyExtension());
-			$compiler->addExtension('cache', new CacheExtension());
 			$compiler->addExtension('dbal', new DbalExtension());
 			$compiler->addConfig(Neonkit::load('
 				dbal:


### PR DESCRIPTION
## BC breaks

### Types registration

Since no types are commented anymore, you cannot use the registration with `commented` property anymore. Just use the simple registration with type and class name:

```neon
nettrine.dbal:
  connection:
    types:
      uuid: Ramsey\Uuid\Doctrine\UuidType # works

      uuid_binary_ordered_time: # does not work, even with ommiting the line with `commented` property
        class: Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType
        commented: false
```

### Server version

Server version must consist of 3 numbers, partial version numer is not allowed.

```neon
nettrine.dbal:
  connection:
    serverVersion: '8.0.0' # always use 3 numbers, versions like '8.0' are no longer supported
```

### Cache

`doctrine/cache` is no longer supported, `psr/cache` is used instead. This integration allows Nette Cache storages and cache objects in addition to PSR-6 cache pools for cache configuration. See docs for more information.